### PR TITLE
add file serving for generated data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ curl "http://localhost:9999/files"
 ["sample_data.json", "clicks.json", "clicks1.json", "clicks2.json", "clickstream_data.json", "clicks3.json"]
 ```
 
+### /file/<file_name>
+Displays the definition and current status of the job named <job_name>.
+Example:
+```
+curl "http://localhost:9999/file/clicks.json"  | tail -5
+```
+```json
+{"time":"2023-08-02T22:27:48.418","user_id":"2142","event_type":"view_cart","client_ip":"127.250.32.144","client_device":"desktop","client_lang":"Arabic","client_country":"Indonesia","referrer":"bing.com/search","keyword":"gifts","product":"Electric shock pen"}
+{"time":"2023-08-02T22:27:48.431","user_id":"2586","event_type":"view_product","client_ip":"127.174.137.91","client_device":"mobile","client_lang":"Mandarin","client_country":"Nigeria","referrer":"amazon.com","keyword":"t-shirts","product":"Toilet golf putting green"}
+{"time":"2023-08-02T22:27:48.710","user_id":"3850","event_type":"search","client_ip":"127.167.21.193","client_device":"mobile","client_lang":"French","client_country":"Nigeria","referrer":"google.com/search","keyword":"Geeky gifts","product":"Novelty toilet paper"}
+{"time":"2023-08-02T22:27:48.899","user_id":"3846","event_type":"view_product","client_ip":"127.74.91.52","client_device":"laptop","client_lang":"English","client_country":"China","referrer":"google.com/search","keyword":"Geeky gifts","product":"Rubber chicken"}
+{"time":"2023-08-02T22:27:48.905","user_id":"1966","event_type":"search","client_ip":"127.167.136.121","client_device":"mobile","client_lang":"English","client_country":"United States","referrer":"bing.com/search","keyword":"Gag gifts","product":"Bubble wrap suit"}
+```
+
+
 ## Command Line Execution 
 
 The Druid Data Driver is a python script that simulates a workload that generates data for Druid ingestion.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The payload for this request has the following format:
     "total_events": "<total number of messages to generate>",
     "concurrency": "<max number of concurrent state machines>",
     "time": "<duration for data generation>",
-    "time_type": [ "SIM" | "REAL" | "<start timestamp>"]
+    "time_type": "SIM | REAL | <start timestamp>"
 }
 ```
 Where:
@@ -70,9 +70,10 @@ Example payload:
 
 ### /jobs
 Displays a list of currently running jobs, including their current status.
-```json
+```
 curl -X GET "http://localhost:9999/jobs"
-
+```
+```json
 [ { "name": "gen_clickstream1", "config_file": "clickstream/clickstream.json", 
     "target": {"type": "file", "path": "/files/clicks1.json"}, 
     "active_sessions": 100, "total_records": 2405, "start_time": "2023-08-02 22:11:39", 
@@ -96,18 +97,21 @@ This request will stop the job named <job_name> if it is running.
 It also removes the job from the list of known jobs as displayed in the /jobs API.
 
 Example:
-```json
+```
 curl -X POST "http://localhost:9999/stop/gen_clickstream1"
-
+```
+```json
 {"message":"Job [gen_clickstream1] stopped successfully."}
 ```
 
 ### /status/\<job_name>
 Displays the definition and current status of the job named <job_name>.
 Example:
-```json
+```
 curl "http://localhost:9999/status/gen_clickstream1"
+```
 
+```json
 { "name": "gen_clickstream1", "config_file": "clickstream/clickstream.json", 
     "target": {"type": "file", "path": "/files/clicks1.json"}, 
     "active_sessions": 100, "total_records": 2405, "start_time": "2023-08-02 22:11:39", 
@@ -118,12 +122,12 @@ curl "http://localhost:9999/status/gen_clickstream1"
 ### /files
 Displays the definition and current status of the job named <job_name>.
 Example:
-```json
-curl "http://localhost:9999/files"
-
-
 ```
-
+curl "http://localhost:9999/files"
+```
+```json
+["sample_data.json", "clicks.json", "clicks1.json", "clicks2.json", "clickstream_data.json", "clicks3.json"]
+```
 
 ## Command Line Execution 
 

--- a/server/index.py
+++ b/server/index.py
@@ -1,7 +1,7 @@
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, send_from_directory
 from datetime import datetime, timedelta
 import dateutil.parser
-import os
+import os, errno
 import json
 import threading
 
@@ -13,6 +13,11 @@ class DataGeneratorServer (threading.Thread):
         super(DataGeneratorServer, self).__init__()
         self._stop = threading.Event()
         self.config = None
+
+        if 'name' in job_definition.keys():
+            self.name = job_definition['name']
+        else:
+            raise KeyError('Job "name" property must be specified.')
 
         if 'config' in job_definition.keys():
             self.config = job_definition['config']
@@ -56,6 +61,7 @@ class DataGeneratorServer (threading.Thread):
                 self.start_time = datetime.now()
             else:
                 self.start_time = dateutil.parser.isoparse(self.time_type)
+                self.start_time = self.start_time + timedelta(seconds=0.001)
                 self.time_type = 'SIM'
         else:
             self.time_type = None
@@ -66,7 +72,7 @@ class DataGeneratorServer (threading.Thread):
 
 
     def run(self):
-        self.driver = DruidDataDriver.DataDriver(self.config, self.target, self.runtime, self.total_recs, self.time_type, self.start_time, self.max_entities)
+        self.driver = DruidDataDriver.DataDriver(self.name, self.config, self.target, self.runtime, self.total_recs, self.time_type, self.start_time, self.max_entities)
         self.driver.simulate( )
 
     def report(self):
@@ -75,57 +81,139 @@ class DataGeneratorServer (threading.Thread):
     def kill(self):
         self.driver.terminate()
 
+    def get_name(self):
+        return self.name
+
 
 
 
 # flask application definition
 app = Flask(__name__)
+
 # save thread list so we can interact with it
 server_list = []
 
+
+def find_job(name):
+    result = None
+    for server in server_list:
+        if server.get_name()==name:
+            result=server
+            break;
+    return result
+
+def delete_file(filename):
+    try:
+        if os.path.exists(filename):
+            os.remove(filename)
+    except OSError as e:
+        if e.errno != errno.ENOENT: # already deleted
+            raise # re-raise exception if a different error occurred
+
 # REST ENDPOINTS
+
+@app.route('/file/<path:path>')
+def serve_file(path):
+    try:
+        return send_from_directory('/files', path, mimetype="Content-Type: text/html; charset=utf-16")
+    except Exception as ex:
+        return '{"message":"ERROR retrieving file ['+path+'].","exception":"'+f'{ex}'+'"}', 400
+
+
 @app.route("/")
 def instructions():
-    return "I am a data generator.\n POST to /start to initiate an data generator."
+    return '{"message": "Data Generator server. POST to /start to initiate an data generator."}'
+
+@app.route("/files")
+def list_generated_files():
+    try:
+        rootDir='/files'
+        files = [os.path.relpath(os.path.join(dirpath, file), rootDir) for (dirpath, dirnames, filenames) in os.walk(rootDir) for file in filenames]
+        file_list = json.dumps(files)
+        return file_list, 200
+    except Exception as ex:
+        return '{"message":"ERROR while listing available files.","exception":'+f'{ex}'+'}', 400
 
 @app.route("/start", methods=['POST'])
 def start_generator():
     try:
         job = request.get_json()
-        job_result = json.dumps(job, indent=2)
     except Exception as ex:
         raise ValueError(f"Failed to parse job payload, request: {request}\n {ex}")
     try:
+        # place all generated files in the target path
+        if 'name' not in job.keys():
+            return '{"message":"ERROR job must have a "name" property."}', 400
+
+        # check if job is already running
+        existing_job = find_job(job['name'])
+        if  existing_job is not None:
+            if existing_job.report()['status'] == 'COMPLETE': # if job is complete then re-start it
+                # remove existing job and continue
+                existing_job.kill()
+                server_list.remove(existing_job)
+            else:
+                return '{"message":"A Job with name ['+job['name']+'] is already running. Use /stop/'+job['name']+' to cancel it and try again."}', 400
+
+        # only use the name of the file, strip any path, the files are generated and read from /files only
+        if job['target']['type']=='file':
+            filename = os.path.join('/files', os.path.basename(job['target']['path']))
+            job['target']['path']=filename
+            # since we are rebuilding the file remove it if it exists:
+            delete_file(filename)
         server = DataGeneratorServer(job)
         server.start()
         server_list.append(server)
-        return f"Starting generator for request [{job_result}]", 200
+        job_result = json.dumps(job, indent=2)
+        return '{"message":"Starting generator for request.", "request":'+job_result+'}', 200
     except Exception as ex:
-        return f'{ex}', 400
+        return '{"message":"ERROR starting data generator job","exception":"'+f'{ex}'+'"}', 400
 
-@app.route("/status")
-def get_status():
-    result = ''
+@app.route("/jobs", methods=['GET'])
+def get_jobs():
+    result = []
     try:
         if len(server_list) == 0:
-            return "No data generation running.", 200
-
+            return '{"message":"Data generation is NOT running."}', 200
         for server in server_list:
             report = server.report()
-            result += '\n'+json.dumps(report)
-        return result, 200
+            result.append( report)
+        return json.dumps(result), 200
     except Exception as ex:
-        return f'Error getting report: {ex}', 400
+        return '{"message":"ERROR in creating report.","exception":'+f'{ex}'+'}', 400
 
-@app.route("/stop", methods=['POST'])
-def stop_generator():
+@app.route("/status/<name>", methods=['GET'])
+def get_status(name):
+    found=False
     try:
+        if len(server_list) == 0:
+            return '{"message":"Data generation is NOT running."}', 200
         for server in server_list:
-            server.kill()
-        server_list.clear()
-        return "Data generation stopped", 200
+            result = server.report()
+            if result['name']==name:
+                found=True
+                break;
+        if found:
+            return json.dumps(result), 200
+        else:
+            return '{"message":"Job ['+name+'] not found"}', 400
     except Exception as ex:
-        return f'{ex}', 400
+        return '{"message":"ERROR in creating report.","exception":'+f'{ex}'+'}', 400
+
+
+@app.route("/stop/<name>", methods=['POST'])
+def stop_generator(name):
+    try:
+        server = find_job(name)
+        if server is not None:
+            server.kill()
+            server_list.remove(server)
+            return '{"message":"Job ['+name+'] stopped successfully."}', 200
+        else:
+            return '{"message":"Job ['+name+'] not found."}', 400
+    except Exception as ex:
+        return '{"message":"ERROR stopping job ['+name+'].","exception":'+f'{ex}'+'}', 400
+
 
 @app.route("/list", methods=['GET'])
 def list_configs():
@@ -135,9 +223,9 @@ def list_configs():
         config_list = json.dumps(files)
         return config_list, 200
     except Exception as ex:
-        return f'{ex}', 400
+        return '{"message":"ERROR while listing available configurations.","exception":'+f'{ex}'+'}', 400
 
 
 if __name__ == "__main__":
-    port = int(os.environ.get('PORT', 5000))
+    port = int(os.environ.get('PORT', 9999))
     app.run(debug=True, host='0.0.0.0', port=port)


### PR DESCRIPTION
- added a /file API endpoint to retrieve generated data files, i.e. directly in SQL based ingestion
- adjusted README to reflect changes
- added "name" property to jobs
- adjusted /stop API to only stop a job by name
- prevent running the same job name twice
- remove generated file if it exists at start of file output jobs